### PR TITLE
Update pulls.js to remove reference to Staging branch

### DIFF
--- a/web/assets/js/pulls.js
+++ b/web/assets/js/pulls.js
@@ -4,7 +4,7 @@
         if ($target.length) {
             $.getJSON('/api/pulls/', function (data) {
                 // console.log(data);
-                $target.append('<option value="staging">Latest Version (staging branch)</option>');
+                $target.append('<option value="staging">Latest Version (features branch)</option>');
                 if (typeof data.pulls !== 'undefined' || !data.pulls.length) {
                     // $target.parent().fadeTo(0, 0);
                     var suggested = false;


### PR DESCRIPTION
We no longer use the Staging branch, so this could be confusing - assuming that it pulls the default branch that should be Features.