### PR TITLE
Add PHP 7.4 support

### DIFF
--- a/.ebextensions/50_php.config
+++ b/.ebextensions/50_php.config
@@ -11,19 +11,19 @@ option_settings:
 
 packages:
   yum:
-    php73-imap: []
+    php74-imap: []
 
 container_commands:
   50_install_imap:
-    test: '[ ! -f /usr/lib64/php/7.3/modules/imap.so ] && echo "imap is not installed"'
-    command: sudo yum install php73-imap -y
+    test: '[ ! -f /usr/lib64/php/7.4/modules/imap.so ] && echo "imap is not installed"'
+    command: sudo yum install php74-imap -y
   51_install_mailparse:
-    test: '[ ! -f /usr/lib64/php/7.3/modules/mailparse.so ] && echo "mailparse is not installed"'
+    test: '[ ! -f /usr/lib64/php/7.4/modules/mailparse.so ] && echo "mailparse is not installed"'
     command: |
       sudo pecl7 install --force mailparse
       sudo -u root bash -c "sed '/extension=\"mailparse.so\"/d' /etc/php.ini > /etc/php.ini"
   52_install_apcu:
-    test: '[ ! -f /usr/lib64/php/7.3/modules/apcu.so ] && echo "apcu is not installed"'
+    test: '[ ! -f /usr/lib64/php/7.4/modules/apcu.so ] && echo "apcu is not installed"'
     command: printf "\n" | sudo pecl7 install --force apcu
 
 files:


### PR DESCRIPTION
Not sure if this is enough - guess you can select PHP 7.4 as the version to use in the Beanstalk UI?